### PR TITLE
fix: update roadmap.json and generate.py to prevent doc drift (#5)

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -383,6 +383,21 @@ def _changelog_from_roadmap(changelog: list[dict]) -> str:
     return "\n".join(lines)
 
 
+_BRANCH_STRATEGY = """\
+## Branch Strategy
+
+All Reporium suite repositories follow the same Git Flow:
+
+- **`dev`** — integration branch; all feature branches target `dev`
+- **`main`** — stable branch; `dev` is merged into `main` via **squash merge** for each release
+- Feature branches: `feature/<name>`, merged to `dev` via squash merge
+- Hotfixes: `hotfix/<name>`, merged to both `main` and `dev`
+
+This applies suite-wide: reporium, reporium-api, reporium-db, reporium-ingestion, \
+reporium-scoring, forksync, reporium-audit, reporium-events, perditio-devkit, and this roadmap repo.\
+"""
+
+
 def build_readme(roadmap: dict, stats_map: dict[str, Optional[dict]], generated_at: str) -> str:
     """Assemble the full README from roadmap data and live stats.
 
@@ -443,6 +458,10 @@ def build_readme(roadmap: dict, stats_map: dict[str, Optional[dict]], generated_
 
 ---
 
+{_BRANCH_STRATEGY}
+
+---
+
 {changelog}
 
 ---
@@ -483,6 +502,10 @@ def build_readme(roadmap: dict, stats_map: dict[str, Optional[dict]], generated_
 ---
 
 {backlog_section}
+
+---
+
+{_BRANCH_STRATEGY}
 
 ---
 

--- a/roadmap.json
+++ b/roadmap.json
@@ -76,14 +76,14 @@
     "deadline": "end of April 2026",
     "items": [
       "100K repos tracked",
-      "repo-intelligence library live on PyPI",
+      "reporium-scoring library live on PyPI",
       "reporium frontend v2 (Figma-designed)"
     ]
   },
   "coming_next": [
     {
-      "name": "repo-intelligence",
-      "repo": "perditioinc/repo-intelligence",
+      "name": "reporium-scoring",
+      "repo": "perditioinc/reporium-scoring",
       "description": "0-100 repo scorer: README, activity, community, CI. Pip-installable."
     },
     {
@@ -121,12 +121,12 @@
     {
       "version": "v0.4.0",
       "date": "2026-03-20",
-      "notes": "reporium-api deployed to Cloud Run ({api_repos_tracked} repos live), reporium-events Pub/Sub system, reporium-audit nightly health checks, perditio-devkit shared tooling, build counters on all nightly repos, Reporium suite badges across all repos — {test_count} tests passing"
+      "notes": "reporium-api deployed to Cloud Run, reporium-events Pub/Sub system, reporium-audit nightly health checks, perditio-devkit shared tooling, build counters on all nightly repos, Reporium suite badges across all repos — live counts shown in Current State above"
     },
     {
       "version": "v0.3.0",
       "date": "2026-03-17",
-      "notes": "reporium-db, reporium-dataset, reporium-metrics, portfolio, repo-intelligence all launched — {test_count} tests passing across all repos"
+      "notes": "reporium-db, reporium-dataset, reporium-metrics, portfolio, reporium-scoring all launched — live test count shown in Current State above"
     },
     {
       "version": "v0.2.0",


### PR DESCRIPTION
## Summary

- Replaces all `repo-intelligence` references with `reporium-scoring` in `roadmap.json` (future milestone, `coming_next` entry, v0.3.0 changelog note)
- Removes frozen `{api_repos_tracked}` and `{test_count}` template placeholders from changelog entries, which would render stale snapshot values; redirects to live Current State section instead
- Adds `_BRANCH_STRATEGY` constant to `generate.py` documenting the suite-wide `dev → main` Git Flow with squash merges rule, wired into both new-structure and legacy README templates

Closes #1, #2, #3, #5

## Test plan

- [x] `python -m py_compile generate.py` passes (syntax clean)
- [x] No `repo-intelligence` references remain in either file
- [x] `_BRANCH_STRATEGY` appears in both template branches in `build_readme`
- [x] Changelog entries no longer contain live-count placeholders that would overwrite PR #4 fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)