### PR TITLE
KAN-ROADMAP: generate.py parity — render solved_lanes + historical_targets

### DIFF
--- a/.audit/2026-04-28/generate-py-parity-jira.md
+++ b/.audit/2026-04-28/generate-py-parity-jira.md
@@ -1,0 +1,143 @@
+# KAN-ROADMAP-generate-py-parity — JIRA fallback
+
+**Lane:** generate-py-parity
+**Date:** 2026-04-28
+**Branch:** `claude/feature/KAN-ROADMAP-generate-py-parity`
+**Base / target:** `main`
+**JIRA:** unavailable in shell at time of writing; this file is the
+JIRA-first fallback per the lane process rule.
+**Owned files:** `generate.py`, `tests/test_generate.py`,
+`.audit/2026-04-28/generate-py-parity-jira.md`
+
+---
+
+## Why this lane exists
+
+PR #10 (`KAN-ROADMAP: roadmap sync v0.8.0 → v0.8.3`, merged 2026-04-26T00:08:03Z)
+added the following hand-written sections to `README.md`:
+
+- `## Solved Lanes — do not re-open` (8 entries, sourced from
+  `roadmap.json:solved_lanes.entries`)
+- `## Historical Targets` (1 entry, sourced from
+  `roadmap.json:historical_targets`)
+- Per-repo `Main HEAD <sha>` strings inside working entries' `evidence` fields
+- All v0.8.x changelog entries (v0.8.4 / v0.8.3 / v0.8.2 / v0.8.1 / v0.8.0)
+- A `Last updated:` footer date tied to the roadmap `as_of` field
+
+The nightly `update.yml` workflow runs `generate.py` and force-commits the
+regenerated README. Three post-merge nightly runs (build 41 on 2026-04-26,
+build 42 on 2026-04-27, build 43 on 2026-04-28) **silently overwrote** the
+`## Solved Lanes` and `## Historical Targets` sections because `build_readme`
+did not read those keys from `roadmap.json`.
+
+This was anticipated in the PR #10 body:
+> **`generate.py` parity gap.** The README contains hand-written sections
+> (Solved Lanes, Historical Targets, explicit per-repo HEADs in Working
+> evidence, the v0.8.x changelog blocks) that `generate.py:build_readme`
+> does not produce. The next nightly auto-build workflow will overwrite
+> these unless `generate.py` is taught about them.
+> Suggested separate lane: `KAN-ROADMAP-generate-py-parity`.
+
+---
+
+## Gap validation (2026-04-28)
+
+```
+python -c "from generate import load_roadmap, build_readme; \
+  print(build_readme(load_roadmap(), {}, '2026-04-28'))" \
+  > /tmp/regenerated_readme.md
+diff README.md /tmp/regenerated_readme.md
+# → empty diff: live README and generated README are identical
+# → confirmed: solved_lanes and historical_targets already overwritten
+```
+
+The live `README.md` on `main` as of 2026-04-28 has no `## Solved Lanes` or
+`## Historical Targets` sections. The nightly has already caused the loss.
+
+### Keys NOT read by build_readme (pre-fix)
+
+| roadmap.json key | Pre-fix | Post-fix |
+|---|---|---|
+| `solved_lanes.entries` | ❌ ignored | ✅ `_solved_lanes_section()` |
+| `historical_targets` | ❌ ignored | ✅ `_historical_targets_section()` |
+| `current_state.not_working` | ✅ already rendered | ✅ unchanged |
+| `changelog[]` (all entries) | ✅ all 13 rendered | ✅ unchanged |
+| working evidence verbatim | ✅ already passed through | ✅ regression test added |
+| `as_of` (footer date) | ❌ not used (`generated_at[:10]`) | ✅ `last_updated = roadmap.get("as_of") or generated_at[:10]` |
+
+---
+
+## What changed
+
+### `generate.py`
+
+Two new private renderer functions (no public API change):
+
+- `_solved_lanes_section(roadmap)` — reads `roadmap["solved_lanes"]`, renders
+  note + each entry's `lane`/`repo`/`resolved_by`/`date`/`summary`. Returns
+  `""` when the key is absent or `entries` is empty (safe omission).
+- `_historical_targets_section(roadmap)` — reads `roadmap["historical_targets"]`,
+  renders each entry's `claim`/`stated_in`/`outcome_as_of_*`. Returns `""` when
+  the key is absent (safe omission).
+
+`build_readme` updated:
+
+- Calls both new helpers; includes each section conditionally between Coming
+  Next and Changelog (separated by `---` dividers only when content is present).
+- Footer date now uses `roadmap.get("as_of") or generated_at[:10]` so the
+  "Last updated:" line reflects when the roadmap was curated, not when the
+  nightly ran.
+
+Public function signatures are **unchanged**: `build_readme`, `load_roadmap`,
+`_format_item`, `_apply_context`, `_apply_context_to_items`,
+`_count_repo_tests`, `_fetch_db_stats`, `_fetch_repo_stats` all retain their
+existing signatures and behaviour.
+
+### `tests/test_generate.py`
+
+Six new tests added (35 → 41 total, all passing):
+
+1. `test_solved_lanes_renders_when_present` — heading and entry content appear
+2. `test_solved_lanes_omitted_when_absent` — no heading when key missing
+3. `test_historical_targets_renders_when_present` — heading and claim appear
+4. `test_historical_targets_omitted_when_absent` — no heading when key missing
+5. `test_changelog_all_entries_rendered_in_order` — 3-entry list stays in order
+6. `test_working_evidence_main_head_survives_render` — `Main HEAD \`4c5f2f3\``
+   passes through verbatim (regression guard against future template changes)
+
+---
+
+## Sections intentionally not made generator-backed
+
+| Section | Decision | Rationale |
+|---|---|---|
+| `REPORIUM_ROADMAP.md` | **Not touched** | It is an extended architecture doc with tables, phases, and prose that have no counterpart in `roadmap.json`. Making it generator-backed would require a major schema extension that is out of scope for a parity lane. |
+| Badge block (`<!-- perditio-badges-start -->`) | **Not touched** | Already correct; constraint in lane brief. |
+| Nightly `update.yml` workflow | **Not touched** | Constraint in lane brief. |
+
+---
+
+## Stop conditions honored
+
+- No application repos modified.
+- No PRs merged or deployed.
+- `roadmap.json` and `README.md` not edited (the README will be regenerated
+  correctly by the next nightly run once this branch lands on main).
+- No public function signatures changed.
+- All 41 tests green.
+
+---
+
+## Acceptance criteria
+
+- [x] `## Solved Lanes — do not re-open` appears in rendered README when
+      `solved_lanes.entries` is non-empty in `roadmap.json`.
+- [x] `## Solved Lanes` is absent when key is missing.
+- [x] `## Historical Targets` appears in rendered README when
+      `historical_targets` is non-empty.
+- [x] `## Historical Targets` is absent when key is missing.
+- [x] All 13 changelog entries render in declared order.
+- [x] `Main HEAD \`4c5f2f3\`` in a working entry's evidence survives rendering.
+- [x] `python -m pytest tests/test_generate.py` — 41 passed.
+- [x] Footer uses `roadmap.json:as_of` when present.
+- [x] No public function signatures changed.

--- a/generate.py
+++ b/generate.py
@@ -383,6 +383,47 @@ def _changelog_from_roadmap(changelog: list[dict]) -> str:
     return "\n".join(lines)
 
 
+def _solved_lanes_section(roadmap: dict) -> str:
+    """Render the 'Solved Lanes — do not re-open' section from roadmap.json:solved_lanes."""
+    solved = roadmap.get("solved_lanes", {})
+    entries = solved.get("entries", [])
+    if not entries:
+        return ""
+    note = solved.get("note", "")
+    lines = ["## Solved Lanes — do not re-open", ""]
+    if note:
+        lines.append(f"_{note}_")
+        lines.append("")
+    for entry in entries:
+        lane = entry.get("lane", "")
+        repo = entry.get("repo", "")
+        resolved_by = entry.get("resolved_by", "")
+        date = entry.get("date", "")
+        summary = entry.get("summary", "")
+        label = f"[**{lane}**](https://github.com/{repo})" if repo else f"**{lane}**"
+        lines.append(f"- {label} — resolved {date} via {resolved_by}")
+        if summary:
+            lines.append(f"  _{summary}_")
+    return "\n".join(lines)
+
+
+def _historical_targets_section(roadmap: dict) -> str:
+    """Render the 'Historical Targets' section from roadmap.json:historical_targets."""
+    targets = roadmap.get("historical_targets", [])
+    if not targets:
+        return ""
+    lines = ["## Historical Targets", ""]
+    for target in targets:
+        stated_in = target.get("stated_in", "")
+        claim = target.get("claim", "")
+        outcome_key = next((k for k in target if k.startswith("outcome_as_of")), None)
+        outcome = target.get(outcome_key, "") if outcome_key else ""
+        lines.append(f"- **{claim}** (stated in {stated_in})")
+        if outcome:
+            lines.append(f"  _{outcome}_")
+    return "\n".join(lines)
+
+
 def build_readme(roadmap: dict, stats_map: dict[str, Optional[dict]], generated_at: str) -> str:
     """Assemble the full README from roadmap data and live stats.
 
@@ -408,7 +449,13 @@ def build_readme(roadmap: dict, stats_map: dict[str, Optional[dict]], generated_
         next_up = _next_up_section(roadmap.get("next_up", {}))
         future = _future_section(roadmap.get("future", {}))
         coming = _plain_section("Coming Next", roadmap.get("coming_next", []))
+        solved = _solved_lanes_section(roadmap)
+        historical = _historical_targets_section(roadmap)
         changelog = _changelog_from_roadmap(roadmap.get("changelog", []))
+        last_updated = roadmap.get("as_of") or generated_at[:10]
+
+        solved_block = f"\n---\n\n{solved}\n" if solved else ""
+        historical_block = f"\n---\n\n{historical}\n" if historical else ""
 
         return f"""# Reporium Roadmap
 <!-- perditio-badges-start -->
@@ -440,14 +487,14 @@ def build_readme(roadmap: dict, stats_map: dict[str, Optional[dict]], generated_
 ---
 
 {coming}
-
+{solved_block}{historical_block}
 ---
 
 {changelog}
 
 ---
 
-*{version_line}Last updated: {generated_at[:10]} · See [CHANGELOG.md](CHANGELOG.md) for version history.*
+*{version_line}Last updated: {last_updated} · See [CHANGELOG.md](CHANGELOG.md) for version history.*
 """
 
     # Legacy structure (live, in_progress, coming_next, backlog)

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -394,3 +394,140 @@ async def test_count_repo_tests_skips_non_test_files():
     async with httpx.AsyncClient(timeout=15) as client:
         count = await _count_repo_tests(client, "tok", "perditioinc/reporium-db")
     assert count == 1
+
+
+# ── solved_lanes rendering ─────────────────────────────────────────────────────
+
+
+def test_solved_lanes_renders_when_present():
+    """solved_lanes.entries produce a '## Solved Lanes' block in the README."""
+    roadmap = {
+        "vision": "test",
+        "current_state": {"working": [], "not_working": []},
+        "fixing_now": [],
+        "next_up": {},
+        "future": {},
+        "coming_next": [],
+        "solved_lanes": {
+            "note": "Do not re-open these.",
+            "entries": [
+                {
+                    "lane": "conftest teardown flake",
+                    "repo": "perditioinc/reporium-api",
+                    "resolved_by": "PR #429",
+                    "date": "2026-04-24",
+                    "summary": "Teardown made non-fatal.",
+                },
+            ],
+        },
+    }
+    readme = build_readme(roadmap, {}, "2026-04-24")
+    assert "## Solved Lanes — do not re-open" in readme
+    assert "conftest teardown flake" in readme
+    assert "PR #429" in readme
+    assert "Do not re-open these." in readme
+
+
+def test_solved_lanes_omitted_when_absent():
+    """README has no solved_lanes heading when the key is not in roadmap.json."""
+    roadmap = {
+        "vision": "test",
+        "current_state": {"working": [], "not_working": []},
+        "fixing_now": [],
+        "next_up": {},
+        "future": {},
+        "coming_next": [],
+    }
+    readme = build_readme(roadmap, {}, "2026-04-24")
+    assert "## Solved Lanes" not in readme
+
+
+# ── historical_targets rendering ───────────────────────────────────────────────
+
+
+def test_historical_targets_renders_when_present():
+    """historical_targets list produces a '## Historical Targets' block."""
+    roadmap = {
+        "vision": "test",
+        "current_state": {"working": [], "not_working": []},
+        "fixing_now": [],
+        "next_up": {},
+        "future": {},
+        "coming_next": [],
+        "historical_targets": [
+            {
+                "stated_in": "v0.7.0 README (2026-03-23)",
+                "claim": "10K repos by end of March 2026",
+                "outcome_as_of_2026_04_24": "Not met. 1,856 repos.",
+            }
+        ],
+    }
+    readme = build_readme(roadmap, {}, "2026-04-24")
+    assert "## Historical Targets" in readme
+    assert "10K repos by end of March 2026" in readme
+    assert "Not met. 1,856 repos." in readme
+
+
+def test_historical_targets_omitted_when_absent():
+    """README has no historical_targets heading when the key is not in roadmap.json."""
+    roadmap = {
+        "vision": "test",
+        "current_state": {"working": [], "not_working": []},
+        "fixing_now": [],
+        "next_up": {},
+        "future": {},
+        "coming_next": [],
+    }
+    readme = build_readme(roadmap, {}, "2026-04-24")
+    assert "## Historical Targets" not in readme
+
+
+# ── changelog ordering ────────────────────────────────────────────────────────
+
+
+def test_changelog_all_entries_rendered_in_order():
+    """All changelog entries appear in the README in declared order."""
+    roadmap = {
+        "vision": "test",
+        "current_state": {"working": [], "not_working": []},
+        "fixing_now": [],
+        "next_up": {},
+        "future": {},
+        "coming_next": [],
+        "changelog": [
+            {"version": "v0.3.0", "date": "2026-03-17", "notes": "Third entry."},
+            {"version": "v0.2.0", "date": "2026-03-16", "notes": "Second entry."},
+            {"version": "v0.1.0", "date": "2026-03-14", "notes": "First entry."},
+        ],
+    }
+    readme = build_readme(roadmap, {}, "2026-04-24")
+    pos_v3 = readme.index("v0.3.0")
+    pos_v2 = readme.index("v0.2.0")
+    pos_v1 = readme.index("v0.1.0")
+    assert pos_v3 < pos_v2 < pos_v1, "changelog entries must appear in declared order"
+
+
+# ── evidence Main HEAD passthrough (regression guard) ─────────────────────────
+
+
+def test_working_evidence_main_head_survives_render():
+    """A working entry whose evidence contains 'Main HEAD abcd1234' renders verbatim."""
+    roadmap = {
+        "vision": "test",
+        "current_state": {
+            "working": [
+                {
+                    "name": "reporium-ingestion v1.3.0",
+                    "repo": "perditioinc/reporium-ingestion",
+                    "evidence": "Cloud Run Job live. Main HEAD `4c5f2f3`; tag v1.3.0.",
+                }
+            ],
+            "not_working": [],
+        },
+        "fixing_now": [],
+        "next_up": {},
+        "future": {},
+        "coming_next": [],
+    }
+    readme = build_readme(roadmap, {}, "2026-04-24")
+    assert "Main HEAD `4c5f2f3`" in readme


### PR DESCRIPTION
## Summary

Closes the `generate.py` parity gap flagged in PR #10. Three nightly runs after PR #10 merged silently overwrote the curated `## Solved Lanes — do not re-open` and `## Historical Targets` sections because `build_readme` did not read those keys from `roadmap.json`. This PR teaches the renderer about them so the nightly is the source of truth, not a hazard.

**Owned files only:** `generate.py`, `tests/test_generate.py`, `.audit/2026-04-28/generate-py-parity-jira.md`

---

## Before / After — README sections

| Section | Before this PR | After this PR |
|---|---|---|
| `## Solved Lanes — do not re-open` | ❌ Hand-maintained in README; overwritten by each nightly run | ✅ Generator-backed via `roadmap.json:solved_lanes.entries` |
| `## Historical Targets` | ❌ Hand-maintained in README; overwritten by each nightly run | ✅ Generator-backed via `roadmap.json:historical_targets` |
| `### Not Working` in Current State | ✅ Already generator-backed (no change) | ✅ Unchanged |
| All changelog entries | ✅ All 13 entries already rendered by `_changelog_from_roadmap` (no change) | ✅ Unchanged |
| Working entry evidence (Main HEAD shas) | ✅ Already passed through verbatim (no change) | ✅ Regression test added to pin this |
| `Last updated:` footer | ❌ Used `generated_at[:10]` (nightly run date, e.g. `2026-04-28`) | ✅ Uses `roadmap.get("as_of") or generated_at[:10]` — reflects curation date (`2026-04-25`) not rebuild date |

---

## Validation notes

### Before fix — diff between live README and generated README

```
$ python -c "from generate import load_roadmap, build_readme; \
    print(build_readme(load_roadmap(), {}, '2026-04-28'))" \
    > /tmp/regenerated_readme.md
$ diff README.md /tmp/regenerated_readme.md
(empty)
```

**Empty diff confirms the loss**: three nightly builds (2026-04-26, 2026-04-27, 2026-04-28) had already overwritten the `## Solved Lanes` and `## Historical Targets` sections added by PR #10. The live README matched the pre-fix renderer exactly — both were missing those sections.

### After fix — new sections present in rendered output

```
$ python -c "from generate import load_roadmap, build_readme; \
    out = build_readme(load_roadmap(), {}, '2026-04-28'); \
    print('\n'.join(l for l in out.splitlines() if l.startswith('## ') or l.startswith('*Platform')))"

## Current State
## Fixing Now
## Next Up — Q2 2026
## Target: 2026 H2
## Coming Next
## Solved Lanes — do not re-open
## Historical Targets
## Changelog
*Platform **v0.7.0** · Last updated: 2026-04-25 · See [CHANGELOG.md](CHANGELOG.md) for version history.*
```

Both sections now present. Footer shows `2026-04-25` (from `roadmap.json:as_of`) instead of `2026-04-28` (nightly run date).

---

## Implementation

Two new private helper functions added to `generate.py`:

- **`_solved_lanes_section(roadmap)`** — renders `roadmap["solved_lanes"]` into `## Solved Lanes — do not re-open`, including the `note` field and each entry's `lane`/`repo`/`resolved_by`/`date`/`summary`. Returns `""` when the key is absent or `entries` is empty — section is cleanly omitted.
- **`_historical_targets_section(roadmap)`** — renders `roadmap["historical_targets"]` into `## Historical Targets`, including each entry's `claim`/`stated_in`/`outcome_as_of_*`. Returns `""` when absent — clean omission.

`build_readme` updated to:
- Call both helpers
- Conditionally insert each section (with `---` divider) between Coming Next and Changelog
- Use `roadmap.get("as_of") or generated_at[:10]` for the footer date

**No public function signatures changed.** `build_readme`, `load_roadmap`, `_format_item`, `_apply_context`, `_apply_context_to_items`, `_count_repo_tests`, `_fetch_db_stats`, `_fetch_repo_stats` all retain their existing signatures — `tests/test_generate.py` imports are unaffected.

---

## Test plan

- [x] 35 pre-existing tests still pass
- [x] `test_solved_lanes_renders_when_present` — heading + all entry fields present when key exists
- [x] `test_solved_lanes_omitted_when_absent` — no heading when `solved_lanes` key missing
- [x] `test_historical_targets_renders_when_present` — heading + claim + outcome present
- [x] `test_historical_targets_omitted_when_absent` — no heading when `historical_targets` key missing
- [x] `test_changelog_all_entries_rendered_in_order` — 3-entry list preserves declared order
- [x] `test_working_evidence_main_head_survives_render` — `Main HEAD \`4c5f2f3\`` passes through verbatim (regression guard)
- [x] **Total: 41 passed** (`python -m pytest tests/test_generate.py` — 0.29s)

---

## Risks and intentional non-round-trips

| Item | Decision | Rationale |
|---|---|---|
| `REPORIUM_ROADMAP.md` | Not made generator-backed | Extended architecture doc (phases, tables, prose) with no counterpart schema in `roadmap.json`. Making it generator-backed would require a separate schema extension PR outside this lane's scope. |
| Badge block | Not touched | Constraint from lane brief. |
| `update.yml` nightly workflow | Not touched | Constraint from lane brief. |
| `roadmap.json` / `README.md` content | Not edited | The README will be regenerated correctly by the next nightly run once this lands on main. No content changes needed — the source-of-truth data is already in `roadmap.json`. |
| Footer date behavior change | Intentional | `as_of` = `2026-04-25` is when the roadmap was last curated; `2026-04-28` was the nightly rebuild date. "Last updated" should reflect curation, not rebuild. Falls back to `generated_at[:10]` when `as_of` is absent. |

---

*JIRA fallback: `.audit/2026-04-28/generate-py-parity-jira.md`*

https://claude.ai/code/session_012wXiMoFzp7a1FmW55BUG8o

---
_Generated by [Claude Code](https://claude.ai/code/session_012wXiMoFzp7a1FmW55BUG8o)_